### PR TITLE
close #39 abstract collision detection into CollisionEngine,

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -8,14 +8,17 @@ class Game {
     this.canvas = canvas
     this.context = context
     this.blocks = []
-    this.firstPlayer = new PlayerOne(canvas, context)
-    this.secondPlayer = new PlayerTwo(canvas, context)
+    this.firstPlayer = null
+    this.secondPlayer = null
+  }
+
+  getPlayers() {
+    this.firstPlayer = new PlayerOne(this)
+    this.secondPlayer = new PlayerTwo(this)
   }
 
   renderBlocks() {
     this.loadBlocks()
-    this.firstPlayer.blocks = this.blocks
-    this.secondPlayer.blocks = this.blocks
     this.blocks.forEach(block => {
       this.context.fillRect(block.x, block.y, block.width, block.height)
     })

--- a/lib/helpers/collisionEngine.js
+++ b/lib/helpers/collisionEngine.js
@@ -1,0 +1,28 @@
+class CollisionEngine {
+  rightCollide(block) {
+    return (block.x - this.speed <= (this.x + this.width) && (this.x + this.width) <= block.x) &&
+      ((block.y < this.y && this.y < block.y + block.height) ||
+      (block.y < this.y + this.height && this.y + this.height < block.y + block.height))
+  }
+
+  leftCollide(block) {
+    return (this.x <= (block.x + block.width + this.speed) && this.x >= (block.x + block.width)) &&
+      ((block.y < this.y && this.y < block.y + block.height) ||
+      (block.y < this.y + this.height && this.y + this.height < block.y + block.height))
+  }
+
+  upCollide(block) {
+    return (this.y <= (block.y + block.height + this.speed) && this.y >= (block.y + block.height)) &&
+      ((block.x < this.x && this.x < block.x + block.width) ||
+      (block.x < this.x + this.width && this.x + this.width < block.x + block.width))
+  }
+
+  downCollide(block) {
+    return ((this.y + this.height) <= block.y && (this.y + this.height) >= (block.y - this.speed)) &&
+      ((block.x < this.x && this.x < block.x + block.width) ||
+      (block.x < this.x + this.width && this.x + this.width < block.x + block.width))
+  }
+
+}
+
+module.exports = CollisionEngine

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,12 +3,13 @@ const canvas = document.getElementById('game');
 const context = canvas.getContext('2d');
 const Game = require('./game')
 
-const match = new Game(canvas, context)
+const game = new Game(canvas, context)
+game.getPlayers()
 
 function play() {
-  if (match.blocks.length === 0) match.renderBlocks()
-  match.firstPlayer.draw()
-  match.secondPlayer.draw()
+  if (game.blocks.length === 0) game.renderBlocks()
+  game.firstPlayer.draw()
+  game.secondPlayer.draw()
   requestAnimationFrame(play)
 }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -1,15 +1,15 @@
+const CollisionEngine = require('./helpers/collisionEngine')
 const Bomb = require('./bomb')
 
 class Player {
-  constructor(x, y, canvas, context) {
+  constructor(x, y, game) {
     this.x = x
     this.y = y
     this.height = 35
     this.width = 35
-    this.canvas = canvas
-    this.context = context
-    this.blocks = []
     this.speed = 3
+    this.game = game
+    this.collisions = new CollisionEngine()
   }
 
   centerX() {
@@ -21,26 +21,26 @@ class Player {
   }
 
   draw() {
-    this.context.fillRect(this.x, this.y, this.width, this.height)
+    this.game.context.fillRect(this.x, this.y, this.width, this.height)
   }
 
   move() {
-    this.context.fillRect(this.x, this.y, this.width, this.height)
+    this.game.context.fillRect(this.x, this.y, this.width, this.height)
   }
 
   clear() {
-    this.context.clearRect(this.x, this.y, this.width, this.height)
+    this.game.context.clearRect(this.x, this.y, this.width, this.height)
   }
 
   plantBomb() {
     const bombY = this.centerY() + (this.height / 2)
-    const bomb = new Bomb(this.centerX(), bombY, this.context)
+    const bomb = new Bomb(this.centerX(), bombY, this.game.context)
     bomb.draw()
   }
 
   moveRight() {
-    if (this.x < this.canvas.width - this.width) {
-      const collidingBlocks = this.blocks.filter(this.rightCollide.bind(this))
+    if (this.x < this.game.canvas.width - this.width) {
+      const collidingBlocks = this.game.blocks.filter(this.collisions.rightCollide.bind(this))
       if (collidingBlocks.length === 0) {
         this.clear()
         this.x += this.speed
@@ -50,33 +50,9 @@ class Player {
     return this
   }
 
-  rightCollide(block) {
-    return (block.x - this.speed <= (this.x + this.width) && (this.x + this.width) <= block.x) &&
-      ((block.y < this.y && this.y < block.y + block.height) ||
-      (block.y < this.y + this.height && this.y + this.height < block.y + block.height))
-  }
-
-  leftCollide(block) {
-    return (this.x <= (block.x + block.width + this.speed) && this.x >= (block.x + block.width)) &&
-      ((block.y < this.y && this.y < block.y + block.height) ||
-      (block.y < this.y + this.height && this.y + this.height < block.y + block.height))
-  }
-
-  downCollide(block) {
-    return ((this.y + this.height) <= block.y && (this.y + this.height) >= (block.y - this.speed)) &&
-      ((block.x < this.x && this.x < block.x + block.width) ||
-      (block.x < this.x + this.width && this.x + this.width < block.x + block.width))
-  }
-
-  upCollide(block) {
-    return (this.y <= (block.y + block.height + this.speed) && this.y >= (block.y + block.height)) &&
-      ((block.x < this.x && this.x < block.x + block.width) ||
-      (block.x < this.x + this.width && this.x + this.width < block.x + block.width))
-  }
-
   moveLeft() {
     if (this.x > 0) {
-      const collidingBlocks = this.blocks.filter(this.leftCollide.bind(this))
+      const collidingBlocks = this.game.blocks.filter(this.collisions.leftCollide.bind(this))
       if (collidingBlocks.length === 0) {
         this.clear()
         this.x -= this.speed
@@ -88,7 +64,7 @@ class Player {
 
   moveUp() {
     if (this.y > 0) {
-      const collidingBlocks = this.blocks.filter(this.upCollide.bind(this))
+      const collidingBlocks = this.game.blocks.filter(this.collisions.upCollide.bind(this))
       if (collidingBlocks.length === 0) {
         this.clear()
         this.y -= this.speed
@@ -99,8 +75,8 @@ class Player {
   }
 
   moveDown() {
-    if (this.y < this.canvas.height - this.height) {
-      const collidingBlocks = this.blocks.filter(this.downCollide.bind(this))
+    if (this.y < this.game.canvas.height - this.height) {
+      const collidingBlocks = this.game.blocks.filter(this.collisions.downCollide.bind(this))
       if (collidingBlocks.length === 0) {
         this.clear()
         this.y += this.speed

--- a/lib/playerOne.js
+++ b/lib/playerOne.js
@@ -1,8 +1,8 @@
 const Player = require('./player')
 
 class PlayerOne extends Player {
-  constructor(canvas, context) {
-    super(0, 0, canvas, context)
+  constructor(game) {
+    super(0, 0, game)
     this.bindControls()
   }
 

--- a/lib/playerTwo.js
+++ b/lib/playerTwo.js
@@ -1,8 +1,8 @@
 const Player = require('./player')
 
 class PlayerTwo extends Player {
-  constructor(canvas, context) {
-    super(1400, 700, canvas, context)
+  constructor(game) {
+    super(1400, 700, game)
     this.bindControls()
   }
 

--- a/test/player.js
+++ b/test/player.js
@@ -1,7 +1,9 @@
 const assert = require('chai').assert
 const Player = require('./../lib/player')
+const Game = require('./../lib/game')
 const stub = require('./support/stub')
 const canvas = { width: 1470, height: 770 }
+
 
 describe('Player', () => {
   context('properties', () => {
@@ -24,8 +26,7 @@ describe('Player', () => {
   })
 
   context('property values', () => {
-    const context = stub().of('fillRect').of('clearRect')
-    const bomber = new Player(null, null, canvas, context)
+    const bomber = new Player(null, null)
 
     it('has starting default height and width', () => {
       assert.equal(bomber.height, 35)
@@ -38,17 +39,21 @@ describe('Player', () => {
   })
 
   context('move method', () => {
-    const context = stub().of('fillRect').of('clearRect')
-    const bomber = new Player(null, null, canvas, context)
 
     it('should call fillRect on canvas', () => {
+      const context = stub().of('fillRect').of('clearRect')
+      const game = new Game(canvas, context)
+      const bomber = new Player(null, null, game)
       bomber.move()
-      assert.equal(bomber.context.fillRect.calls.length, 1)
+      assert.equal(game.context.fillRect.calls.length, 1)
     })
 
     it('should pass its values to fillRect', () => {
+      const context = stub().of('fillRect').of('clearRect')
+      const game = new Game(canvas, context)
+      const bomber = new Player(null, null, game)
       bomber.move()
-      const fillRectParams = bomber.context.fillRect.calls[0]
+      const fillRectParams = game.context.fillRect.calls[0]
       assert.equal(fillRectParams[0], bomber.x)
       assert.equal(fillRectParams[1], bomber.y)
       assert.equal(fillRectParams[2], bomber.width)
@@ -57,18 +62,22 @@ describe('Player', () => {
   })
 
   context('clear method', () => {
-    const context = stub().of('fillRect').of('clearRect')
-    const bomber = new Player(null, null, canvas, context)
 
     it('should call clearRect on canvas', () => {
+      const context = stub().of('fillRect').of('clearRect')
+      const game = new Game(canvas, context)
+      const bomber = new Player(null, null, game)
       bomber.clear()
-      const clearRectCalls = bomber.context.clearRect.calls
+      const clearRectCalls = game.context.clearRect.calls
       assert.equal(clearRectCalls.length, 1)
     })
 
     it('should pass properties to clearRect', () => {
+      const context = stub().of('fillRect').of('clearRect')
+      const game = new Game(canvas, context)
+      const bomber = new Player(null, null, game)
       bomber.clear()
-      const clearRectParams = bomber.context.clearRect.calls[0]
+      const clearRectParams = game.context.clearRect.calls[0]
       assert.equal(clearRectParams[0], bomber.x)
       assert.equal(clearRectParams[1], bomber.y)
       assert.equal(clearRectParams[2], bomber.width)
@@ -78,7 +87,8 @@ describe('Player', () => {
 
   context('movement', () => {
     const context = stub().of('fillRect').of('clearRect')
-    const bomber = new Player(null, null, canvas, context)
+    const game = new Game(canvas, context)
+    const bomber = new Player(null, null, game)
 
     it('has a function called "moveRight"', () => {
       assert.isFunction(bomber.moveRight)
@@ -98,9 +108,10 @@ describe('Player', () => {
   })
 
   context('movement results', () => {
-    const context = stub().of('fillRect').of('clearRect')
     it('"moveRight" increases x by speed', () => {
-      const bomber = new Player(30, 30, canvas, context)
+      const context = stub().of('fillRect').of('clearRect')
+      const game = new Game(canvas, context)
+      const bomber = new Player(30, 30, game)
       assert.equal(bomber.x, 30)
 
       bomber.speed = 7
@@ -109,7 +120,9 @@ describe('Player', () => {
     })
 
     it('"moveLeft" decreases x by speed', () => {
-      const bomber = new Player(51, 30, canvas, context)
+      const context = stub().of('fillRect').of('clearRect')
+      const game = new Game(canvas, context)
+      const bomber = new Player(51, 30, game)
       assert.equal(bomber.x, 51)
 
       bomber.moveLeft()
@@ -117,7 +130,9 @@ describe('Player', () => {
     })
 
     it('"moveUp" decreases y by speed', () => {
-      const bomber = new Player(30, 31, canvas, context)
+      const context = stub().of('fillRect').of('clearRect')
+      const game = new Game(canvas, context)
+      const bomber = new Player(30, 31, game)
       assert.equal(bomber.y, 31)
 
       bomber.speed = 4
@@ -126,7 +141,9 @@ describe('Player', () => {
     })
 
     it('"moveDown" increases y by speed', () => {
-      const bomber = new Player(30, 30, canvas, context)
+      const context = stub().of('fillRect').of('clearRect')
+      const game = new Game(canvas, context)
+      const bomber = new Player(30, 30, game)
       assert.equal(bomber.y, 30)
 
       bomber.speed = 1
@@ -137,8 +154,9 @@ describe('Player', () => {
 
   context('movement boundaries', () => {
     const context = stub().of('fillRect').of('clearRect')
+    const game = new Game(canvas, context)
     it('"moveRight" cannot move outside the canvas ', () => {
-      const bomber = new Player(1470, 770, canvas, context)
+      const bomber = new Player(1470, 770, game)
       assert.equal(bomber.x, 1470)
 
       bomber.moveRight()
@@ -146,7 +164,7 @@ describe('Player', () => {
     })
 
     it('"moveLeft" cannot move outside the canvas ', () => {
-      const bomber = new Player(0, 773, canvas, context)
+      const bomber = new Player(0, 773, game)
       assert.equal(bomber.x, 0)
 
       bomber.moveLeft()
@@ -154,7 +172,7 @@ describe('Player', () => {
     })
 
     it('"moveUp" cannot move outside the canvas ', () => {
-      const bomber = new Player(30, 30, canvas, context)
+      const bomber = new Player(30, 30, game)
       assert.equal(bomber.y, 30)
 
       bomber.moveUp()
@@ -162,7 +180,7 @@ describe('Player', () => {
     })
 
     it('"moveDown" cannot move outside the canvas ', () => {
-      const bomber = new Player(30, 740, canvas, context)
+      const bomber = new Player(30, 740, game)
       assert.equal(bomber.y, 740)
 
       bomber.moveDown()


### PR DESCRIPTION
adjusted players to get instantiated with Game,
player no longer keeps context, canvas, blocks properties,
moved player instantiation to separate Game function so player tests do not break.
